### PR TITLE
Delete round functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -1557,6 +1557,25 @@
                     </div>
                 </form>
             </div>
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Delete Round?</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Do you really want to delete that round?</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                            No, Cancel
+                        </button>
+                        <button type="button" id="confirmDeleteBtn" class="btn btn-primary" onclick="">
+                            Yes, Delete Round
+                        </button>
+                    </div>
+                </div>
+            </div>
         </main>
         <script
             src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"

--- a/scripts/roundsMode.js
+++ b/scripts/roundsMode.js
@@ -218,6 +218,19 @@ writeRoundToTable(thisRound,rowIndex);
 }
 
 /*************************************************************************
+ * @function deleteRound
+ * @desc
+ * Deletes a round from the "Rounds" table and from local storage
+ * @param roundId -- the unique id of the round to be deleted
+ * @returns -- true if round could be deleted, false otherwise
+ *************************************************************************/
+function deleteRound(roundId) {
+  GlobalUserData.rounds = GlobalUserData.rounds.filter(function (round) {
+      return round.roundNum !== roundId;
+  });
+}
+
+/*************************************************************************
  * @function confirmDelete
  * @desc
  * Present pop-up modal dialog asking user to confirm delete operation

--- a/scripts/roundsMode.js
+++ b/scripts/roundsMode.js
@@ -218,6 +218,45 @@ writeRoundToTable(thisRound,rowIndex);
 }
 
 /*************************************************************************
+ * @function confirmDelete
+ * @desc
+ * Present pop-up modal dialog asking user to confirm delete operation
+ * @param roundId -- the unique id of the round to be deleted
+ * @returns -- true if user confirms delete, false otherwise
+ *************************************************************************/
+function confirmDelete(roundId) {
+  //TO DO: Present modal dialog prompting user to confirm delete
+  //Return true if user confirms delete, false otherwise
+  let modal = new bootstrap.Modal(
+      document.getElementById("confirmDeleteRoundModal")
+  );
+  let confirmBtn = document.getElementById("confirmDeleteBtn");
+  confirmBtn.addEventListener("click", function (event) {
+      event.preventDefault();
+      console.log("deleting round with id " + roundId);
+      for (var i = 0; i < GlobalRoundsTable.rows.length; i++) {
+          let row = GlobalRoundsTable.rows[i];
+          // Check if the id of the row matches the id you're looking for
+          if (row.id === "r-" + roundId) {
+              GlobalRoundsTable.deleteRow(i);
+              break;
+          }
+      }
+      deleteRound(roundId);
+      localStorage.setItem(
+          GlobalUserData.accountInfo.email,
+          JSON.stringify(GlobalUserData)
+      );
+      GlobalRoundsTableCaption.textContent =
+          "Table displaying " +
+          (GlobalRoundsTable.rows.length - 1) +
+          " speedgolf rounds";
+      modal.hide();
+  });
+  modal.show();
+}
+
+/*************************************************************************
 * @function populateRoundsTable 
 * @desc 
 * Iterate through the userData.rounds array, adding a row corresponding


### PR DESCRIPTION
# Description
Add "delete round" functionality to the SpeedScore app. A user can delete a round by clicking on the garbage can icon associated with the round in the "Rounds" table.

# Related Issue(s)
Addresses #1 

# Type of Change
- [X] New Feature
- [ ] Bug Fix
- [ ] Documentation update
- [ ] Other (describe)

# Testing
I manually tested this functionality by creating and deleting rounds.

# Pre-Submission Checklist
- [X] The code executes; my changes do not break the build
- [X] My changes do not generate new warnings
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added automated tests demonstrating that the feature works or that fix is correct
- [ ] New and existing unit tests pass locally with my changes
- [X] Any changes on which this PR depends have been merged and published in upstream modules